### PR TITLE
Envoy-OpenTracing integration.

### DIFF
--- a/bazel/target_recipes.bzl
+++ b/bazel/target_recipes.bzl
@@ -12,6 +12,7 @@ TARGET_RECIPES = {
     "googletest": "googletest",
     "tcmalloc_and_profiler": "gperftools",
     "http_parser": "http-parser",
+    "opentracing": "opentracing",
     "lightstep": "lightstep",
     "nghttp2": "nghttp2",
     "protobuf": "protobuf",

--- a/ci/build_container/Makefile
+++ b/ci/build_container/Makefile
@@ -53,5 +53,5 @@ $(THIRDPARTY_DEPS)/%.dep: $(RECIPES)/%.sh
 # Special support for targets that need protobuf, and hence take a dependency on protobuf.dep.
 PROTOBUF_BUILD ?= $(THIRDPARTY_BUILD)/$(if $(BUILD_DISTINCT),protobuf.dep,)
 
-$(THIRDPARTY_DEPS)/lightstep.dep: $(RECIPES)/lightstep.sh $(THIRDPARTY_DEPS)/protobuf.dep
+$(THIRDPARTY_DEPS)/lightstep.dep: $(RECIPES)/lightstep.sh $(THIRDPARTY_DEPS)/protobuf.dep $(THIRDPARTY_DEPS)/opentracing.dep
 	@+$(call build-recipe,PROTOBUF_BUILD=$(PROTOBUF_BUILD))

--- a/ci/build_container/build_recipes/lightstep.sh
+++ b/ci/build_container/build_recipes/lightstep.sh
@@ -4,7 +4,7 @@ set -e
 
 VERSION=0.4
 
-git clone https://github.com/lightstep/lightstep-tracer-cpp.git
+git clone -b logging https://github.com/rnburn/lightstep-tracer-cpp-1.git lightstep-tracer-cpp
 git clone https://github.com/lightstep/lightstep-tracer-common.git lightstep-tracer-cpp/lightstep-tracer-common/
 cd lightstep-tracer-cpp
 mkdir .build

--- a/ci/build_container/build_recipes/lightstep.sh
+++ b/ci/build_container/build_recipes/lightstep.sh
@@ -2,29 +2,37 @@
 
 set -e
 
-VERSION=0.36
+VERSION=0.4
 
-wget -O lightstep-tracer-cpp-$VERSION.tar.gz https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v${VERSION//./_}/lightstep-tracer-cpp-$VERSION.tar.gz
-tar xf lightstep-tracer-cpp-$VERSION.tar.gz
-cd lightstep-tracer-cpp-$VERSION
-
-# see https://github.com/lyft/envoy/issues/1387 for progress
-cat > ../lightstep-missing-header.diff << EOF
---- ./src/c++11/lightstep/options.h.bak	2017-08-04 09:30:19.527076744 -0400
-+++ ./src/c++11/lightstep/options.h	2017-08-04 09:30:33.742106924 -0400
-@@ -5,6 +5,7 @@
- // Options for Tracer implementations, starting Spans, and finishing
- // Spans.
- 
-+#include <functional>
- #include <chrono>
- #include <memory>
- 
-EOF
-patch -p0 < ../lightstep-missing-header.diff
-
-# Added for legacy compatibility, should not be needed in new build recipes.
-[ -z "$PROTOBUF_BUILD" ] && PROTOBUF_BUILD="$THIRDPARTY_BUILD"
-./configure --disable-grpc --prefix=$THIRDPARTY_BUILD --enable-shared=no \
-	    protobuf_CFLAGS="-I$PROTOBUF_BUILD/include" protobuf_LIBS="-L$PROTOBUF_BUILD/lib -lprotobuf" PROTOC=$PROTOBUF_BUILD/bin/protoc
+git clone https://github.com/lightstep/lightstep-tracer-cpp.git
+git clone https://github.com/lightstep/lightstep-tracer-common.git lightstep-tracer-cpp/lightstep-tracer-common/
+cd lightstep-tracer-cpp
+mkdir .build
+cd .build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$THIRDPARTY_BUILD -DLS_WITH_GRPC=OFF ..
 make V=1 install
+
+# wget -O lightstep-tracer-cpp-$VERSION.tar.gz https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v${VERSION//./_}/lightstep-tracer-cpp-$VERSION.tar.gz
+# tar xf lightstep-tracer-cpp-$VERSION.tar.gz
+# cd lightstep-tracer-cpp-$VERSION
+
+# # see https://github.com/lyft/envoy/issues/1387 for progress
+# cat > ../lightstep-missing-header.diff << EOF
+# --- ./src/c++11/lightstep/options.h.bak	2017-08-04 09:30:19.527076744 -0400
+# +++ ./src/c++11/lightstep/options.h	2017-08-04 09:30:33.742106924 -0400
+# @@ -5,6 +5,7 @@
+#  // Options for Tracer implementations, starting Spans, and finishing
+#  // Spans.
+ 
+# +#include <functional>
+#  #include <chrono>
+#  #include <memory>
+ 
+# EOF
+# patch -p0 < ../lightstep-missing-header.diff
+
+# # Added for legacy compatibility, should not be needed in new build recipes.
+# [ -z "$PROTOBUF_BUILD" ] && PROTOBUF_BUILD="$THIRDPARTY_BUILD"
+# ./configure --disable-grpc --prefix=$THIRDPARTY_BUILD --enable-shared=no \
+# 	    protobuf_CFLAGS="-I$PROTOBUF_BUILD/include" protobuf_LIBS="-L$PROTOBUF_BUILD/lib -lprotobuf" PROTOC=$PROTOBUF_BUILD/bin/protoc
+# make V=1 install

--- a/ci/build_container/build_recipes/opentracing.sh
+++ b/ci/build_container/build_recipes/opentracing.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+VERSION=0.1
+
+git clone https://github.com/opentracing/opentracing-cpp
+cd opentracing-cpp
+mkdir .build
+cd .build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$THIRDPARY_BUILD ..
+make V=1 install

--- a/ci/build_container/build_recipes/opentracing.sh
+++ b/ci/build_container/build_recipes/opentracing.sh
@@ -8,5 +8,5 @@ git clone https://github.com/opentracing/opentracing-cpp
 cd opentracing-cpp
 mkdir .build
 cd .build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$THIRDPARY_BUILD ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$THIRDPARTY_BUILD ..
 make V=1 install

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -57,16 +57,15 @@ cc_library(
 
 cc_library(
     name = "lightstep",
-    srcs = ["thirdparty_build/lib/liblightstep_core_cxx11.a"],
+    srcs = ["thirdparty_build/lib/liblightstep_tracer.a"],
     hdrs = glob([
         "thirdparty_build/include/lightstep/**/*.h",
-        "thirdparty_build/include/mapbox_variant/**/*.hpp",
-    ]) + [
-        "thirdparty_build/include/collector.pb.h",
-        "thirdparty_build/include/lightstep_carrier.pb.h",
-    ],
+    ]),
     includes = ["thirdparty_build/include"],
-    deps = [":protobuf"],
+    deps = [
+        ":protobuf", 
+        ":opentracing",
+    ],
 )
 
 cc_library(

--- a/ci/prebuilt/BUILD
+++ b/ci/prebuilt/BUILD
@@ -70,6 +70,15 @@ cc_library(
 )
 
 cc_library(
+    name = "opentracing",
+    srcs = ["thirdparty_build/lib/libopentracing.a"],
+    hdrs = glob([
+        "thirdparty_build/include/opentracing/**/*.h",
+    ]),
+    includes = ["thirdparty_build/include"],
+)
+
+cc_library(
     name = "nghttp2",
     srcs = ["thirdparty_build/lib/libnghttp2.a"],
     hdrs = glob(["thirdparty_build/include/nghttp2/**/*.h"]),

--- a/docs/install/requirements.rst
+++ b/docs/install/requirements.rst
@@ -18,6 +18,7 @@ Envoy has the following requirements:
 * `gperftools <https://github.com/gperftools/gperftools>`_ (last tested with 2.6.1)
 * `BoringSSL <https://boringssl.googlesource.com/boringssl>`_ (last tested with sha 68f84f5c40644e029ed066999448696b01caba7a).
 * `protobuf <https://github.com/google/protobuf>`_ (last tested with 3.4.0)
+* `opentracing-cpp <https://github.com/opentracing/opentracing-cpp>`_ (last tested with 0.1)
 * `lightstep-tracer-cpp <https://github.com/lightstep/lightstep-tracer-cpp/>`_ (last tested with 0.36)
 * `rapidjson <https://github.com/miloyip/rapidjson/>`_ (last tested with 1.1.0)
 * `c-ares <https://github.com/c-ares/c-ares>`_ (last tested with 1.13.0)

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -12,10 +12,13 @@ envoy_cc_library(
     name = "http_tracer_lib",
     srcs = [
         "http_tracer_impl.cc",
+        "opentracing_driver_impl.cc",
     ],
     hdrs = [
         "http_tracer_impl.h",
+        "opentracing_driver_impl.h",
     ],
+    external_deps = ["opentracing"],
     deps = [
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/runtime:runtime_interface",

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -45,7 +45,7 @@ envoy_cc_library(
     hdrs = [
         "lightstep_tracer_impl.h",
     ],
-    external_deps = ["lightstep"],
+    external_deps = ["lightstep", "opentracing"],
     deps = [
         ":http_tracer_lib",
     ],

--- a/source/common/tracing/BUILD
+++ b/source/common/tracing/BUILD
@@ -48,7 +48,7 @@ envoy_cc_library(
     hdrs = [
         "lightstep_tracer_impl.h",
     ],
-    external_deps = ["lightstep", "opentracing"],
+    external_deps = ["lightstep"],
     deps = [
         ":http_tracer_lib",
     ],

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -50,6 +50,7 @@ void LightStepDriver::LightStepTransporter::onSuccess(Http::MessagePtr&& respons
   } catch (const Grpc::Exception& ex) {
     Grpc::Common::chargeStat(*driver_.cluster(), lightstep::CollectorServiceFullName(),
                              lightstep::CollectorMethodName(), false);
+    // TODO(rnburn): Need to return a more specific std::error_code.
     active_callback_->OnFailure(std::error_code());
   }
 }

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -58,6 +58,7 @@ void LightStepDriver::LightStepTransporter::onSuccess(Http::MessagePtr&& respons
 void LightStepDriver::LightStepTransporter::onFailure(Http::AsyncClient::FailureReason) {
   Grpc::Common::chargeStat(*driver_.cluster(), lightstep::CollectorServiceFullName(),
                            lightstep::CollectorMethodName(), false);
+  // TODO(rnburn): Need to return a more specific std::error_code.
   active_callback_->OnFailure(std::error_code());
 }
 

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -16,21 +16,51 @@ namespace Envoy {
 namespace Tracing {
 
 LightStepDriver::LightStepTransporter::LightStepTransporter(LightStepDriver& driver)
-  : driver_(driver) {}
+    : driver_(driver) {}
 
 void LightStepDriver::LightStepTransporter::Send(
-    const google::protobuf::Message& /*request*/, google::protobuf::Message& response,
+    const google::protobuf::Message& request, google::protobuf::Message& response,
     void (*on_success)(void* context), void (*on_failure)(std::error_code error, void* context),
     void* context) {
   on_success_callback_ = on_success;
   on_failure_callback_ = on_failure;
   active_response_ = &response;
   active_context_ = context;
+
+  Http::MessagePtr message =
+      Grpc::Common::prepareHeaders(driver_.cluster()->name(), lightstep::CollectorServiceFullName(),
+                                   lightstep::CollectorMethodName());
+  message->body() = Grpc::Common::serializeBody(request);
+
+  uint64_t timeout =
+      driver_.runtime().snapshot().getInteger("tracing.lightstep.request_timeout", 5000U);
+  driver_.clusterManager()
+      .httpAsyncClientForCluster(driver_.cluster()->name())
+      .send(std::move(message), *this, std::chrono::milliseconds(timeout));
 }
 
-void LightStepDriver::LightStepTransporter::onSuccess(Http::MessagePtr&&) {}
+void LightStepDriver::LightStepTransporter::onSuccess(Http::MessagePtr&& response) {
+  try {
+    Grpc::Common::validateResponse(*response);
 
-void LightStepDriver::LightStepTransporter::onFailure(Http::AsyncClient::FailureReason) {}
+    Grpc::Common::chargeStat(*driver_.cluster(), lightstep::CollectorServiceFullName(),
+                             lightstep::CollectorMethodName(), true);
+    if (!active_response_->ParseFromString(response->bodyAsString())) {
+      throw EnvoyException("Failed to parse LightStep collector response");
+    }
+    on_success_callback_(active_context_);
+  } catch (const Grpc::Exception& ex) {
+    Grpc::Common::chargeStat(*driver_.cluster(), lightstep::CollectorServiceFullName(),
+                             lightstep::CollectorMethodName(), false);
+    on_failure_callback_(std::error_code(), active_context_);
+  }
+}
+
+void LightStepDriver::LightStepTransporter::onFailure(Http::AsyncClient::FailureReason) {
+  Grpc::Common::chargeStat(*driver_.cluster(), lightstep::CollectorServiceFullName(),
+                           lightstep::CollectorMethodName(), false);
+  on_failure_callback_(std::error_code(), active_context_);
+}
 
 LightStepDriver::TlsLightStepTracer::TlsLightStepTracer(
     std::shared_ptr<opentracing::Tracer>&& tracer, LightStepDriver& driver)

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -21,11 +21,10 @@ LightStepDriver::TlsLightStepTracer::TlsLightStepTracer(
 
 LightStepDriver::LightStepDriver(const Json::Object& config,
                                  Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
-                                 ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
-                                 std::unique_ptr<lightstep::TracerOptions> options)
+                                 ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime)
     : cm_(cluster_manager), tracer_stats_{LIGHTSTEP_TRACER_STATS(
                                 POOL_COUNTER_PREFIX(stats, "tracing.lightstep."))},
-      tls_(tls.allocateSlot()), runtime_(runtime), options_(std::move(options)) {
+      tls_(tls.allocateSlot()), runtime_(runtime) {
   Upstream::ThreadLocalCluster* cluster = cm_.get(config.getString("collector_cluster"));
   if (!cluster) {
     throw EnvoyException(fmt::format("{} collector cluster is not defined on cluster manager level",

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -63,13 +63,30 @@ void LightStepDriver::LightStepTransporter::onFailure(Http::AsyncClient::Failure
 }
 
 LightStepDriver::TlsLightStepTracer::TlsLightStepTracer(
-    std::shared_ptr<opentracing::Tracer>&& tracer, LightStepDriver& driver)
-    : tracer_(std::move(tracer)), driver_(driver) {}
+    std::shared_ptr<lightstep::LightStepTracer>&& tracer, LightStepDriver& driver,
+    Event::Dispatcher& dispatcher)
+    : tracer_(std::move(tracer)), driver_(driver) {
+  flush_timer_ = dispatcher.createTimer([this]() -> void {
+    driver_.tracerStats().timer_flushed_.inc();
+    tracer_->Flush();
+    enableTimer();
+  });
+
+  enableTimer();
+}
+
+const opentracing::Tracer& LightStepDriver::TlsLightStepTracer::tracer() const { return *tracer_; }
+
+void LightStepDriver::TlsLightStepTracer::enableTimer() {
+  uint64_t flush_interval =
+      driver_.runtime().snapshot().getInteger("tracing.lightstep.flush_interval_ms", 1000U);
+  flush_timer_->enableTimer(std::chrono::milliseconds(flush_interval));
+}
 
 LightStepDriver::LightStepDriver(const Json::Object& config,
                                  Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
                                  ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
-                                 const lightstep::LightStepTracerOptions& /*options*/)
+                                 const lightstep::LightStepTracerOptions& options)
     : cm_(cluster_manager), tracer_stats_{LIGHTSTEP_TRACER_STATS(
                                 POOL_COUNTER_PREFIX(stats, "tracing.lightstep."))},
       tls_(tls.allocateSlot()), runtime_(runtime) {
@@ -85,16 +102,23 @@ LightStepDriver::LightStepDriver(const Json::Object& config,
         fmt::format("{} collector cluster must support http2 for gRPC calls", cluster_->name()));
   }
 
-  tls_->set([this](Event::Dispatcher & /*dispatcher*/) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-    std::shared_ptr<opentracing::Tracer> tracer = opentracing::MakeNoopTracer();
+  tls_->set(
+      [this, &options](Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+        lightstep::LightStepTracerOptions tls_options;
+        tls_options.access_token = options.access_token;
+        tls_options.component_name = options.component_name;
+        tls_options.use_thread = false;
+        tls_options.transporter.reset(new LightStepTransporter{*this});
+        std::shared_ptr<lightstep::LightStepTracer> tracer =
+            lightstep::MakeLightStepTracer(std::move(tls_options));
 
-    return ThreadLocal::ThreadLocalObjectSharedPtr{
-        new TlsLightStepTracer(std::move(tracer), *this)};
-  });
+        return ThreadLocal::ThreadLocalObjectSharedPtr{
+            new TlsLightStepTracer(std::move(tracer), *this, dispatcher)};
+      });
 }
 
 const opentracing::Tracer& LightStepDriver::tracer() const {
-  return *tls_->getTyped<TlsLightStepTracer>().tracer_;
+  return tls_->getTyped<TlsLightStepTracer>().tracer();
 }
 
 } // namespace Tracing

--- a/source/common/tracing/lightstep_tracer_impl.cc
+++ b/source/common/tracing/lightstep_tracer_impl.cc
@@ -15,96 +15,9 @@
 namespace Envoy {
 namespace Tracing {
 
-LightStepSpan::LightStepSpan(lightstep::Span& span, lightstep::Tracer& tracer)
-    : span_(span), tracer_(tracer) {}
-
-void LightStepSpan::finishSpan(SpanFinalizer& finalizer) {
-  finalizer.finalize(*this);
-  span_.Finish();
-}
-
-void LightStepSpan::setTag(const std::string& name, const std::string& value) {
-  span_.SetTag(name, value);
-}
-
-void LightStepSpan::injectContext(Http::HeaderMap& request_headers) {
-  lightstep::BinaryCarrier ctx;
-  tracer_.Inject(context(), lightstep::CarrierFormat::LightStepBinaryCarrier,
-                 lightstep::ProtoWriter(&ctx));
-  const std::string current_span_context = ctx.SerializeAsString();
-  request_headers.insertOtSpanContext().value(
-      Base64::encode(current_span_context.c_str(), current_span_context.length()));
-}
-
-SpanPtr LightStepSpan::spawnChild(const std::string& name, SystemTime start_time) {
-  lightstep::Span ls_span = tracer_.StartSpan(
-      name, {lightstep::ChildOf(span_.context()), lightstep::StartTimestamp(start_time)});
-  return SpanPtr{new LightStepSpan(ls_span, tracer_)};
-}
-
-LightStepRecorder::LightStepRecorder(const lightstep::TracerImpl& tracer, LightStepDriver& driver,
-                                     Event::Dispatcher& dispatcher)
-    : builder_(tracer), driver_(driver) {
-  flush_timer_ = dispatcher.createTimer([this]() -> void {
-    driver_.tracerStats().timer_flushed_.inc();
-    flushSpans();
-    enableTimer();
-  });
-
-  enableTimer();
-}
-
-void LightStepRecorder::RecordSpan(lightstep::collector::Span&& span) {
-  builder_.addSpan(std::move(span));
-
-  uint64_t min_flush_spans =
-      driver_.runtime().snapshot().getInteger("tracing.lightstep.min_flush_spans", 5U);
-  if (builder_.pendingSpans() == min_flush_spans) {
-    flushSpans();
-  }
-}
-
-bool LightStepRecorder::FlushWithTimeout(lightstep::Duration) {
-  // Note: We don't expect this to be called, since the Tracer
-  // reference is private to its LightStepSink.
-  return true;
-}
-
-std::unique_ptr<lightstep::Recorder>
-LightStepRecorder::NewInstance(LightStepDriver& driver, Event::Dispatcher& dispatcher,
-                               const lightstep::TracerImpl& tracer) {
-  return std::unique_ptr<lightstep::Recorder>(new LightStepRecorder(tracer, driver, dispatcher));
-}
-
-void LightStepRecorder::enableTimer() {
-  uint64_t flush_interval =
-      driver_.runtime().snapshot().getInteger("tracing.lightstep.flush_interval_ms", 1000U);
-  flush_timer_->enableTimer(std::chrono::milliseconds(flush_interval));
-}
-
-void LightStepRecorder::flushSpans() {
-  if (builder_.pendingSpans() != 0) {
-    driver_.tracerStats().spans_sent_.add(builder_.pendingSpans());
-    lightstep::collector::ReportRequest request;
-    std::swap(request, builder_.pending());
-
-    Http::MessagePtr message = Grpc::Common::prepareHeaders(driver_.cluster()->name(),
-                                                            lightstep::CollectorServiceFullName(),
-                                                            lightstep::CollectorMethodName());
-
-    message->body() = Grpc::Common::serializeBody(std::move(request));
-
-    uint64_t timeout =
-        driver_.runtime().snapshot().getInteger("tracing.lightstep.request_timeout", 5000U);
-    driver_.clusterManager()
-        .httpAsyncClientForCluster(driver_.cluster()->name())
-        .send(std::move(message), *this, std::chrono::milliseconds(timeout));
-  }
-}
-
-LightStepDriver::TlsLightStepTracer::TlsLightStepTracer(lightstep::Tracer tracer,
-                                                        LightStepDriver& driver)
-    : tracer_(new lightstep::Tracer(tracer)), driver_(driver) {}
+LightStepDriver::TlsLightStepTracer::TlsLightStepTracer(
+    std::shared_ptr<opentracing::Tracer>&& tracer, LightStepDriver& driver)
+    : tracer_(std::move(tracer)), driver_(driver) {}
 
 LightStepDriver::LightStepDriver(const Json::Object& config,
                                  Upstream::ClusterManager& cluster_manager, Stats::Store& stats,
@@ -125,58 +38,16 @@ LightStepDriver::LightStepDriver(const Json::Object& config,
         fmt::format("{} collector cluster must support http2 for gRPC calls", cluster_->name()));
   }
 
-  tls_->set([this](Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-    lightstep::Tracer tracer(lightstep::NewUserDefinedTransportLightStepTracer(
-        *options_, std::bind(&LightStepRecorder::NewInstance, std::ref(*this), std::ref(dispatcher),
-                             std::placeholders::_1)));
+  tls_->set([this](Event::Dispatcher & /*dispatcher*/) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+    std::shared_ptr<opentracing::Tracer> tracer = opentracing::MakeNoopTracer();
 
     return ThreadLocal::ThreadLocalObjectSharedPtr{
         new TlsLightStepTracer(std::move(tracer), *this)};
   });
 }
 
-SpanPtr LightStepDriver::startSpan(Http::HeaderMap& request_headers,
-                                   const std::string& operation_name, SystemTime start_time) {
-  lightstep::Tracer& tracer = *tls_->getTyped<TlsLightStepTracer>().tracer_;
-  LightStepSpanPtr active_span;
-
-  if (request_headers.OtSpanContext()) {
-    // Extract downstream context from HTTP carrier.
-    // This code is safe even if decode returns empty string or data is malformed.
-    std::string parent_context = Base64::decode(request_headers.OtSpanContext()->value().c_str());
-    lightstep::BinaryCarrier ctx;
-    ctx.ParseFromString(parent_context);
-
-    lightstep::SpanContext parent_span_ctx = tracer.Extract(
-        lightstep::CarrierFormat::LightStepBinaryCarrier, lightstep::ProtoReader(ctx));
-    lightstep::Span ls_span =
-        tracer.StartSpan(operation_name, {lightstep::ChildOf(parent_span_ctx),
-                                          lightstep::StartTimestamp(start_time)});
-    active_span.reset(new LightStepSpan(ls_span, tracer));
-  } else {
-    lightstep::Span ls_span =
-        tracer.StartSpan(operation_name, {lightstep::StartTimestamp(start_time)});
-    active_span.reset(new LightStepSpan(ls_span, tracer));
-  }
-
-  return std::move(active_span);
-}
-
-void LightStepRecorder::onFailure(Http::AsyncClient::FailureReason) {
-  Grpc::Common::chargeStat(*driver_.cluster(), lightstep::CollectorServiceFullName(),
-                           lightstep::CollectorMethodName(), false);
-}
-
-void LightStepRecorder::onSuccess(Http::MessagePtr&& msg) {
-  try {
-    Grpc::Common::validateResponse(*msg);
-
-    Grpc::Common::chargeStat(*driver_.cluster(), lightstep::CollectorServiceFullName(),
-                             lightstep::CollectorMethodName(), true);
-  } catch (const Grpc::Exception& ex) {
-    Grpc::Common::chargeStat(*driver_.cluster(), lightstep::CollectorServiceFullName(),
-                             lightstep::CollectorMethodName(), false);
-  }
+const opentracing::Tracer& LightStepDriver::tracer() const {
+  return *tls_->getTyped<TlsLightStepTracer>().tracer_;
 }
 
 } // namespace Tracing

--- a/source/common/tracing/lightstep_tracer_impl.h
+++ b/source/common/tracing/lightstep_tracer_impl.h
@@ -72,11 +72,19 @@ private:
     LightStepDriver& driver_;
   };
 
-  struct TlsLightStepTracer : ThreadLocal::ThreadLocalObject {
-    TlsLightStepTracer(std::shared_ptr<opentracing::Tracer>&& tracer, LightStepDriver& driver);
+  class TlsLightStepTracer : public ThreadLocal::ThreadLocalObject {
+  public:
+    TlsLightStepTracer(std::shared_ptr<lightstep::LightStepTracer>&& tracer,
+                       LightStepDriver& driver, Event::Dispatcher& dispatcher);
 
-    std::shared_ptr<opentracing::Tracer> tracer_;
+    const opentracing::Tracer& tracer() const;
+
+  private:
+    void enableTimer();
+
+    std::shared_ptr<lightstep::LightStepTracer> tracer_;
     LightStepDriver& driver_;
+    Event::TimerPtr flush_timer_;
   };
 
   Upstream::ClusterManager& cm_;

--- a/source/common/tracing/lightstep_tracer_impl.h
+++ b/source/common/tracing/lightstep_tracer_impl.h
@@ -14,8 +14,6 @@
 #include "common/tracing/opentracing_driver_impl.h"
 #include "common/json/json_loader.h"
 
-#include "lightstep/carrier.h"
-#include "lightstep/tracer.h"
 #include "opentracing/tracer.h"
 #include "opentracing/noop.h"
 
@@ -39,8 +37,7 @@ struct LightstepTracerStats {
 class LightStepDriver : public OpenTracingDriver {
 public:
   LightStepDriver(const Json::Object& config, Upstream::ClusterManager& cluster_manager,
-                  Stats::Store& stats, ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
-                  std::unique_ptr<lightstep::TracerOptions> options);
+                  Stats::Store& stats, ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime);
 
   // Tracer::OpenTracingDriver
   const opentracing::Tracer& tracer() const override;
@@ -63,7 +60,6 @@ private:
   LightstepTracerStats tracer_stats_;
   ThreadLocal::SlotPtr tls_;
   Runtime::Loader& runtime_;
-  std::unique_ptr<lightstep::TracerOptions> options_;
 };
 
 } // Tracing

--- a/source/common/tracing/lightstep_tracer_impl.h
+++ b/source/common/tracing/lightstep_tracer_impl.h
@@ -57,18 +57,15 @@ private:
 
     // lightstep::AsyncTransporter
     void Send(const google::protobuf::Message& request, google::protobuf::Message& response,
-              void (*on_success)(void* context),
-              void (*on_failure)(std::error_code error, void* context), void* context) override;
+              lightstep::AsyncTransporter::Callback& callback) override;
 
     // Http::AsyncClient::Callbacks
     void onSuccess(Http::MessagePtr&& response) override;
     void onFailure(Http::AsyncClient::FailureReason) override;
 
   private:
-    void (*on_success_callback_)(void* context) = nullptr;
-    void (*on_failure_callback_)(std::error_code error, void* context) = nullptr;
+    lightstep::AsyncTransporter::Callback* active_callback_ = nullptr;
     google::protobuf::Message* active_response_ = nullptr;
-    void* active_context_ = nullptr;
     LightStepDriver& driver_;
   };
 

--- a/source/common/tracing/lightstep_tracer_impl.h
+++ b/source/common/tracing/lightstep_tracer_impl.h
@@ -40,7 +40,7 @@ class LightStepDriver : public OpenTracingDriver {
 public:
   LightStepDriver(const Json::Object& config, Upstream::ClusterManager& cluster_manager,
                   Stats::Store& stats, ThreadLocal::SlotAllocator& tls, Runtime::Loader& runtime,
-                  const lightstep::LightStepTracerOptions& options);
+                  std::unique_ptr<lightstep::LightStepTracerOptions>&& options);
 
   // Tracer::OpenTracingDriver
   const opentracing::Tracer& tracer() const override;
@@ -92,6 +92,7 @@ private:
   LightstepTracerStats tracer_stats_;
   ThreadLocal::SlotPtr tls_;
   Runtime::Loader& runtime_;
+  std::unique_ptr<lightstep::LightStepTracerOptions> options_;
 };
 
 } // Tracing

--- a/source/common/tracing/opentracing_driver_impl.cc
+++ b/source/common/tracing/opentracing_driver_impl.cc
@@ -1,0 +1,31 @@
+#include "common/tracing/opentracing_driver_impl.h"
+
+namespace Envoy {
+namespace Tracing {
+
+OpenTracingSpan::OpenTracingSpan(std::unique_ptr<opentracing::Span>&& span)
+    : span_(std::move(span)) {}
+
+void OpenTracingSpan::finishSpan(SpanFinalizer& finalizer) {
+  finalizer.finalize(*this);
+  span_->Finish();
+}
+
+void OpenTracingSpan::setTag(const std::string& name, const std::string& value) {
+  span_->SetTag(name, value);
+}
+
+void OpenTracingSpan::injectContext(Http::HeaderMap& /*request_headers*/) {}
+
+SpanPtr OpenTracingSpan::spawnChild(const std::string& /*name*/, SystemTime /*start_time*/) {
+  return nullptr;
+}
+
+SpanPtr OpenTracingDriver::startSpan(Http::HeaderMap& /*request_headers*/,
+                                     const std::string& /*operation_name*/,
+                                     SystemTime /*start_time*/) {
+  return nullptr;
+}
+
+} // namespace Tracing
+} // namespace Envoy

--- a/source/common/tracing/opentracing_driver_impl.cc
+++ b/source/common/tracing/opentracing_driver_impl.cc
@@ -1,10 +1,16 @@
 #include "common/tracing/opentracing_driver_impl.h"
 
+#include <sstream>
+
+#include "common/common/base64.h"
+
 namespace Envoy {
 namespace Tracing {
 
 OpenTracingSpan::OpenTracingSpan(std::unique_ptr<opentracing::Span>&& span)
-    : span_(std::move(span)) {}
+    : span_(std::move(span)) {
+  // TODO (rnburn): check span_ != nullptr?
+}
 
 void OpenTracingSpan::finishSpan(SpanFinalizer& finalizer) {
   finalizer.finalize(*this);
@@ -15,16 +21,43 @@ void OpenTracingSpan::setTag(const std::string& name, const std::string& value) 
   span_->SetTag(name, value);
 }
 
-void OpenTracingSpan::injectContext(Http::HeaderMap& /*request_headers*/) {}
-
-SpanPtr OpenTracingSpan::spawnChild(const std::string& /*name*/, SystemTime /*start_time*/) {
-  return nullptr;
+void OpenTracingSpan::injectContext(Http::HeaderMap& request_headers) {
+  std::ostringstream oss;
+  span_->tracer().Inject(span_->context(), oss);
+  const std::string current_span_context = oss.str();
+  request_headers.insertOtSpanContext().value(
+      Base64::encode(current_span_context.c_str(), current_span_context.length()));
 }
 
-SpanPtr OpenTracingDriver::startSpan(Http::HeaderMap& /*request_headers*/,
-                                     const std::string& /*operation_name*/,
-                                     SystemTime /*start_time*/) {
-  return nullptr;
+SpanPtr OpenTracingSpan::spawnChild(const std::string& name, SystemTime start_time) {
+  std::unique_ptr<opentracing::Span> ot_span = span_->tracer().StartSpan(
+      name, {opentracing::ChildOf(&span_->context()), opentracing::StartTimestamp(start_time)});
+  return SpanPtr{new OpenTracingSpan(std::move(ot_span))};
+}
+
+SpanPtr OpenTracingDriver::startSpan(Http::HeaderMap& request_headers,
+                                     const std::string& operation_name, SystemTime start_time) {
+  const opentracing::Tracer& tracer = this->tracer();
+  std::unique_ptr<opentracing::Span> active_span;
+  if (request_headers.OtSpanContext()) {
+    std::string parent_context = Base64::decode(request_headers.OtSpanContext()->value().c_str());
+    std::istringstream iss(parent_context);
+    opentracing::expected<std::unique_ptr<opentracing::SpanContext>> parent_span_ctx_maybe =
+        tracer.Extract(iss);
+    std::unique_ptr<opentracing::SpanContext> parent_span_ctx;
+    // TODO (rnburn): What to do if tracer.Extract fails?
+    if (parent_span_ctx_maybe) {
+      parent_span_ctx = std::move(*parent_span_ctx_maybe);
+    }
+    active_span = tracer.StartSpan(operation_name, {opentracing::ChildOf(parent_span_ctx.get()),
+                                                    opentracing::StartTimestamp(start_time)});
+  } else {
+    active_span = tracer.StartSpan(operation_name, {opentracing::StartTimestamp(start_time)});
+  }
+  if (active_span == nullptr) {
+    return nullptr;
+  }
+  return SpanPtr{new OpenTracingSpan(std::move(active_span))};
 }
 
 } // namespace Tracing

--- a/source/common/tracing/opentracing_driver_impl.cc
+++ b/source/common/tracing/opentracing_driver_impl.cc
@@ -32,6 +32,9 @@ void OpenTracingSpan::injectContext(Http::HeaderMap& request_headers) {
 SpanPtr OpenTracingSpan::spawnChild(const std::string& name, SystemTime start_time) {
   std::unique_ptr<opentracing::Span> ot_span = span_->tracer().StartSpan(
       name, {opentracing::ChildOf(&span_->context()), opentracing::StartTimestamp(start_time)});
+  if (ot_span == nullptr) {
+    return nullptr;
+  }
   return SpanPtr{new OpenTracingSpan(std::move(ot_span))};
 }
 

--- a/source/common/tracing/opentracing_driver_impl.h
+++ b/source/common/tracing/opentracing_driver_impl.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "envoy/tracing/http_tracer.h"
+
+#include "opentracing/span.h"
+
+namespace Envoy {
+namespace Tracing {
+
+class OpenTracingSpan : public Span {
+public:
+  explicit OpenTracingSpan(std::unique_ptr<opentracing::Span>&& span);
+
+  // Tracing::Span
+  void finishSpan(SpanFinalizer& finalizer) override;
+  void setTag(const std::string& name, const std::string& value) override;
+  void injectContext(Http::HeaderMap& request_headers) override;
+  SpanPtr spawnChild(const std::string& name, SystemTime start_time) override;
+
+private:
+  std::unique_ptr<opentracing::Span> span_;
+};
+
+class OpenTracingDriver : public Driver {
+public:
+  // Tracer::TracingDriver
+  SpanPtr startSpan(Http::HeaderMap& request_headers, const std::string& operation_name,
+                    SystemTime start_time) override;
+};
+
+} // namespace Tracing
+} // namespace Envoy

--- a/source/common/tracing/opentracing_driver_impl.h
+++ b/source/common/tracing/opentracing_driver_impl.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/tracing/http_tracer.h"
 
-#include "opentracing/span.h"
+#include "opentracing/tracer.h"
 
 namespace Envoy {
 namespace Tracing {
@@ -26,6 +28,8 @@ public:
   // Tracer::TracingDriver
   SpanPtr startSpan(Http::HeaderMap& request_headers, const std::string& operation_name,
                     SystemTime start_time) override;
+
+  virtual const opentracing::Tracer& tracer() const = 0;
 };
 
 } // namespace Tracing

--- a/source/server/config/http/lightstep_http_tracer.cc
+++ b/source/server/config/http/lightstep_http_tracer.cc
@@ -8,9 +8,6 @@
 #include "common/tracing/http_tracer_impl.h"
 #include "common/tracing/lightstep_tracer_impl.h"
 
-#include "lightstep/options.h"
-#include "lightstep/tracer.h"
-
 namespace Envoy {
 namespace Server {
 namespace Configuration {
@@ -20,18 +17,16 @@ LightstepHttpTracerFactory::createHttpTracer(const Json::Object& json_config,
                                              Server::Instance& server,
                                              Upstream::ClusterManager& cluster_manager) {
 
-  Envoy::Runtime::RandomGenerator& rand = server.random();
+  /* std::unique_ptr<lightstep::TracerOptions> opts(new lightstep::TracerOptions()); */
+  /* opts->access_token = server.api().fileReadToEnd(json_config.getString("access_token_file")); */
+  /* StringUtil::rtrim(opts->access_token); */
 
-  std::unique_ptr<lightstep::TracerOptions> opts(new lightstep::TracerOptions());
-  opts->access_token = server.api().fileReadToEnd(json_config.getString("access_token_file"));
-  StringUtil::rtrim(opts->access_token);
-
-  opts->tracer_attributes["lightstep.component_name"] = server.localInfo().clusterName();
-  opts->guid_generator = [&rand]() { return rand.random(); };
+  /* opts->tracer_attributes["lightstep.component_name"] = server.localInfo().clusterName(); */
+  /* opts->guid_generator = [&rand]() { return rand.random(); }; */
 
   Tracing::DriverPtr lightstep_driver(
       new Tracing::LightStepDriver(json_config, cluster_manager, server.stats(),
-                                   server.threadLocal(), server.runtime(), std::move(opts)));
+                                   server.threadLocal(), server.runtime()));
   return Tracing::HttpTracerPtr(
       new Tracing::HttpTracerImpl(std::move(lightstep_driver), server.localInfo()));
 }

--- a/source/server/config/http/lightstep_http_tracer.cc
+++ b/source/server/config/http/lightstep_http_tracer.cc
@@ -8,6 +8,8 @@
 #include "common/tracing/http_tracer_impl.h"
 #include "common/tracing/lightstep_tracer_impl.h"
 
+#include "lightstep/tracer.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
@@ -17,16 +19,13 @@ LightstepHttpTracerFactory::createHttpTracer(const Json::Object& json_config,
                                              Server::Instance& server,
                                              Upstream::ClusterManager& cluster_manager) {
 
-  /* std::unique_ptr<lightstep::TracerOptions> opts(new lightstep::TracerOptions()); */
-  /* opts->access_token = server.api().fileReadToEnd(json_config.getString("access_token_file")); */
-  /* StringUtil::rtrim(opts->access_token); */
+  lightstep::LightStepTracerOptions opts;
+  opts.access_token = server.api().fileReadToEnd(json_config.getString("access_token_file"));
+  StringUtil::rtrim(opts.access_token);
+  opts.component_name = server.localInfo().clusterName();
 
-  /* opts->tracer_attributes["lightstep.component_name"] = server.localInfo().clusterName(); */
-  /* opts->guid_generator = [&rand]() { return rand.random(); }; */
-
-  Tracing::DriverPtr lightstep_driver(
-      new Tracing::LightStepDriver(json_config, cluster_manager, server.stats(),
-                                   server.threadLocal(), server.runtime()));
+  Tracing::DriverPtr lightstep_driver(new Tracing::LightStepDriver(
+      json_config, cluster_manager, server.stats(), server.threadLocal(), server.runtime(), opts));
   return Tracing::HttpTracerPtr(
       new Tracing::HttpTracerImpl(std::move(lightstep_driver), server.localInfo()));
 }


### PR DESCRIPTION
Summary of the changes made:
* Add an [OpenTracingSpan class](https://github.com/rnburn/envoy/blob/design/source/common/tracing/opentracing_driver_impl.h#L12) that maps Envoy's span API to the equivalent OpenTracing span methods.
* [Uses](https://github.com/rnburn/envoy/blob/design/source/common/tracing/opentracing_driver_impl.cc#L26) OpenTracing binary propagation [API](https://github.com/rnburn/opentracing-cpp/blob/master/c%2B%2B11/include/opentracing/tracer.h#L101) to encode the span context.
* Add an [OpenTracingDriver class](https://github.com/rnburn/envoy/blob/design/source/common/tracing/opentracing_driver_impl.h#L26) that implements the `startSpan` and returns an OpenTracingSpan.
* Change the [LightStepDriver](https://github.com/rnburn/envoy/blob/design/source/common/tracing/lightstep_tracer_impl.h#L39) to derive from the OpenTracingDriver. Like before, it stores thread-local instances of the LightStepTracer and exposes them as an `opentracing::Tracer` to the OpenTracingDriver class.
* Instead of defining an entire reporter for the LightStep tracer, Envoy's implementation now just provides an [AsyncTransporter](https://github.com/rnburn/envoy/blob/design/source/common/tracing/lightstep_tracer_impl.h#L54) and works with the `google::protobuf::Message` classes so that LightStep's protobuf definitions aren't exposed.

Items still left to do:
* Support the [SpansSent Stat](https://github.com/rnburn/envoy/blob/checkpoint0/source/common/tracing/lightstep_tracer_impl.cc#L87).
* Fix linking/loading [issue](https://github.com/rnburn/envoy/issues/2) with debug build.
* Update the [unit tests](https://github.com/rnburn/envoy/blob/checkpoint0/test/common/tracing/lightstep_tracer_impl_test.cc).
* Change to `opentracing.sh` and `lightstep.sh` build scripts to use tagged GitHub versions.